### PR TITLE
Fix typo on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,9 @@
 
 ### Build any text into JavaScript
 
-```npm install grunt-string-to-js --save``
+```
+npm install grunt-string-to-js --save
+```
 
 Grunt configuration
 


### PR DESCRIPTION
There was a missing backtick on the install instructions.